### PR TITLE
Handle the case with multiple properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { ReplaySubject } from 'rxjs/ReplaySubject'
 
-const subjects = new WeakMap()
+type SubjectByProp = Map<string, ReplaySubject<any>>
+
+const subjects: WeakMap<Object, SubjectByProp> = new WeakMap()
 
 export function ObservableInput() {
   return (target, propertyKey) => {
@@ -11,10 +13,12 @@ export function ObservableInput() {
         this[propertyKey].next(value)
       },
       get() {
-        let subject = subjects.get(this)
+        const subjectByProp: SubjectByProp = subjects.get(this) || new Map()
+        let subject = subjectByProp.get(propertyKey)
         if (! subject)  {
           subject = new ReplaySubject<any>(1)
-          subjects.set(this, subject)
+          subjectByProp.set(propertyKey, subject)
+          subjects.set(this, subjectByProp)
         }
         return subject
       },


### PR DESCRIPTION
The original solution is great, thank you so much!
But it won't work when there are more than one @observableinput. Namely, the latest input will overwrite the previous ones.
I have slightly modified it, so that the WeakMap (by component) will contain Maps (by component's property), so that there will be one Subject per each property of each component. And it works.
Please ignore the package.json changes. I did those to publish the forked lib ASAP for my team.
Thank you!