### PR TITLE
Return observable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function ObservableInput() {
           subjectByProp.set(propertyKey, subject)
           subjects.set(this, subjectByProp)
         }
-        return subject
+        return subject.asObservable()
       },
     })
   }


### PR DESCRIPTION
The library should not expose the Subject, but instead return an Observable, using [asObservable](https://rxjs-dev.firebaseapp.com/api/index/class/Subject#asobservable-).