### PR TITLE
fix TypeError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Observable, ReplaySubject } from 'rxjs'
 
-interface Cache { observable: Observable<any>; subject: ReplaySubject<any> }
-type CacheByProp = Map<string, Cache>
+interface SubjectAndObservable { observable: Observable<any>; subject: ReplaySubject<any> }
+type CacheByProp = Map<string, SubjectAndObservable>
 
 const cache = new WeakMap<Object, CacheByProp>()
 
@@ -15,7 +15,7 @@ const getCacheByProp = (instance: Object): CacheByProp => {
   return newCacheByProp
 }
 
-const getCacheOfProp = (instance: Object, propertyKey: string): Cache => {
+const getCacheOfProp = (instance: Object, propertyKey: string): SubjectAndObservable => {
   const cacheByProp = getCacheByProp(instance)
   const cacheOfProp = cacheByProp.get(propertyKey)
   if (cacheOfProp) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,15 @@ import { Observable, ReplaySubject } from 'rxjs'
 interface SubjectAndObservable { observable: Observable<any>; subject: ReplaySubject<any> }
 type ComponentSubjectsAndObservables = Map<string, SubjectAndObservable>
 
-const cache = new WeakMap<Object, ComponentSubjectsAndObservables>()
+const subjectsAndObservables = new WeakMap<Object, ComponentSubjectsAndObservables>()
 
 const getComponentSubjectsAndObservables = (instance: Object): ComponentSubjectsAndObservables => {
-  const componentSubjectsAndObservables: ComponentSubjectsAndObservables = cache.get(instance)
+  const componentSubjectsAndObservables: ComponentSubjectsAndObservables = subjectsAndObservables.get(instance)
   if (componentSubjectsAndObservables) {
     return componentSubjectsAndObservables
   }
   const newComponentSubjectsAndObservables: ComponentSubjectsAndObservables = new Map()
-  cache.set(instance, newComponentSubjectsAndObservables)
+  subjectsAndObservables.set(instance, newComponentSubjectsAndObservables)
   return newComponentSubjectsAndObservables
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,29 @@
 import { Observable, ReplaySubject } from 'rxjs'
 
 interface SubjectAndObservable { observable: Observable<any>; subject: ReplaySubject<any> }
-type CacheByProp = Map<string, SubjectAndObservable>
+type ComponentSubjectsAndObservables = Map<string, SubjectAndObservable>
 
-const cache = new WeakMap<Object, CacheByProp>()
+const cache = new WeakMap<Object, ComponentSubjectsAndObservables>()
 
-const getCacheByProp = (instance: Object): CacheByProp => {
-  const cacheByProp: CacheByProp = cache.get(instance)
-  if (cacheByProp) {
-    return cacheByProp
+const getComponentSubjectsAndObservables = (instance: Object): ComponentSubjectsAndObservables => {
+  const componentSubjectsAndObservables: ComponentSubjectsAndObservables = cache.get(instance)
+  if (componentSubjectsAndObservables) {
+    return componentSubjectsAndObservables
   }
-  const newCacheByProp: CacheByProp = new Map()
-  cache.set(instance, newCacheByProp)
-  return newCacheByProp
+  const newComponentSubjectsAndObservables: ComponentSubjectsAndObservables = new Map()
+  cache.set(instance, newComponentSubjectsAndObservables)
+  return newComponentSubjectsAndObservables
 }
 
 const getCacheOfProp = (instance: Object, propertyKey: string): SubjectAndObservable => {
-  const cacheByProp = getCacheByProp(instance)
-  const cacheOfProp = cacheByProp.get(propertyKey)
+  const componentSubjectsAndObservables = getComponentSubjectsAndObservables(instance)
+  const cacheOfProp = componentSubjectsAndObservables.get(propertyKey)
   if (cacheOfProp) {
     return cacheOfProp
   }
   const subject = new ReplaySubject<any>(1)
   const newCacheOfProp = { observable: subject.asObservable(), subject }
-  cacheByProp.set(propertyKey, newCacheOfProp)
+  componentSubjectsAndObservables.set(propertyKey, newCacheOfProp)
   return newCacheOfProp
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Observable, ReplaySubject } from 'rxjs'
 interface Cache { observable: Observable<any>; subject: ReplaySubject<any> }
 type CacheByProp = Map<string, Cache>
 
-const cache: WeakMap<Object, CacheByProp> = new WeakMap()
+const cache = new WeakMap<Object, CacheByProp>()
 
 const getCacheByProp = (instance: Object): CacheByProp => {
   const cacheByProp: CacheByProp = cache.get(instance)
@@ -22,7 +22,7 @@ const getCacheOfProp = (instance: Object, propertyKey: string): Cache => {
     return cacheOfProp
   }
   const subject = new ReplaySubject<any>(1)
-  const newCacheOfProp: Cache = { observable: subject.asObservable(), subject }
+  const newCacheOfProp = { observable: subject.asObservable(), subject }
   cacheByProp.set(propertyKey, newCacheOfProp)
   return newCacheOfProp
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,16 +15,16 @@ const getComponentSubjectsAndObservables = (instance: Object): ComponentSubjects
   return newComponentSubjectsAndObservables
 }
 
-const getCacheOfProp = (instance: Object, propertyKey: string): SubjectAndObservable => {
+const getSubjectAndObservable = (instance: Object, propertyKey: string): SubjectAndObservable => {
   const componentSubjectsAndObservables = getComponentSubjectsAndObservables(instance)
-  const cacheOfProp = componentSubjectsAndObservables.get(propertyKey)
-  if (cacheOfProp) {
-    return cacheOfProp
+  const subjectAndObservable = componentSubjectsAndObservables.get(propertyKey)
+  if (subjectAndObservable) {
+    return subjectAndObservable
   }
   const subject = new ReplaySubject<any>(1)
-  const newCacheOfProp = { observable: subject.asObservable(), subject }
-  componentSubjectsAndObservables.set(propertyKey, newCacheOfProp)
-  return newCacheOfProp
+  const newSubjectAndObservable = { observable: subject.asObservable(), subject }
+  componentSubjectsAndObservables.set(propertyKey, newSubjectAndObservable)
+  return newSubjectAndObservable
 }
 
 export function ObservableInput() {
@@ -33,10 +33,10 @@ export function ObservableInput() {
 
     Object.defineProperty(target, propertyKey, {
       set(value) {
-        getCacheOfProp(this, propertyKey).subject.next(value)
+        getSubjectAndObservable(this, propertyKey).subject.next(value)
       },
       get() {
-        return getCacheOfProp(this, propertyKey).observable
+        return getSubjectAndObservable(this, propertyKey).observable
       },
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,22 +4,29 @@ type SubjectByProp = Map<string, ReplaySubject<any>>
 
 const subjects: WeakMap<Object, SubjectByProp> = new WeakMap()
 
+const getSubject = (instance: any, propertyKey: string): ReplaySubject<any> => {
+  const subjectByProp: SubjectByProp = subjects.get(instance) || new Map()
+  let subject = subjectByProp.get(propertyKey)
+  if (subject) {
+    return subject
+  }
+  subject = new ReplaySubject<any>(1)
+  subjectByProp.set(propertyKey, subject)
+  subjects.set(instance, subjectByProp)
+  return subject
+}
+
 export function ObservableInput() {
   return (target, propertyKey) => {
     delete target[propertyKey]
 
     Object.defineProperty(target, propertyKey, {
       set(value) {
-        this[propertyKey].next(value)
+        const subject = getSubject(this, propertyKey)
+        subject.next(value)
       },
       get() {
-        const subjectByProp: SubjectByProp = subjects.get(this) || new Map()
-        let subject = subjectByProp.get(propertyKey)
-        if (! subject)  {
-          subject = new ReplaySubject<any>(1)
-          subjectByProp.set(propertyKey, subject)
-          subjects.set(this, subjectByProp)
-        }
+        const subject = getSubject(this, propertyKey)
         return subject.asObservable()
       },
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,41 @@
-import { ReplaySubject } from 'rxjs'
+import { Observable, ReplaySubject } from 'rxjs'
 
+type ObservableByProp = Map<string, Observable<any>>
 type SubjectByProp = Map<string, ReplaySubject<any>>
 
+const observables: WeakMap<Object, ObservableByProp> = new WeakMap()
 const subjects: WeakMap<Object, SubjectByProp> = new WeakMap()
 
-const getSubject = (instance: any, propertyKey: string): ReplaySubject<any> => {
-  const subjectByProp: SubjectByProp = subjects.get(instance) || new Map()
-  let subject = subjectByProp.get(propertyKey)
+const getMap = <T> (weakMap: WeakMap<Object, Map<string, T>>, instance: Object): Map<string, T> => {
+  const map: Map<string, T> = weakMap.get(instance)
+  if (map) {
+    return map
+  }
+  const newMap: Map<string, T> = new Map()
+  weakMap.set(instance, newMap)
+  return newMap
+}
+
+const getSubject = (instance: Object, propertyKey: string): ReplaySubject<any> => {
+  const subjectByProp = getMap(subjects, instance)
+  const subject = subjectByProp.get(propertyKey)
   if (subject) {
     return subject
   }
-  subject = new ReplaySubject<any>(1)
-  subjectByProp.set(propertyKey, subject)
-  subjects.set(instance, subjectByProp)
-  return subject
+  const newSubject = new ReplaySubject<any>(1)
+  subjectByProp.set(propertyKey, newSubject)
+  return newSubject
+}
+
+const getObservable = (instance: Object, propertyKey: string): Observable<any> => {
+  const observableByProp = getMap(observables, instance)
+  const observable = observableByProp.get(propertyKey)
+  if (observable) {
+    return observable
+  }
+  const newObservable = getSubject(instance, propertyKey).asObservable()
+  observableByProp.set(propertyKey, newObservable)
+  return newObservable
 }
 
 export function ObservableInput() {
@@ -22,12 +44,10 @@ export function ObservableInput() {
 
     Object.defineProperty(target, propertyKey, {
       set(value) {
-        const subject = getSubject(this, propertyKey)
-        subject.next(value)
+        getSubject(this, propertyKey).next(value)
       },
       get() {
-        const subject = getSubject(this, propertyKey)
-        return subject.asObservable()
+        return getObservable(this, propertyKey)
       },
     })
   }


### PR DESCRIPTION
Hi @ohjames,

I was reading through the source code of this repo today to understand how it works. I stumbled upon this line:

```typescript
this[propertyKey].next(value)
```

I wondered why this works because the getter returns an Observable which should not expose any function called `next()`. After some debugging I noticed that the latest changes aren't published to npm yet and that it actually doesn't work anymore if I use the latest source code from GitHub. As expected I get a TypeError.

```text
TypeError: this[propertyKey].next is not a function
```

I created this pull request to fix the problem.

The second commit of this pull request adds a second WeakMap to cache the Observables returned by the getter. I did this because RxJS will otherwise create a new Observable each time the getter is called.

https://github.com/ReactiveX/rxjs/blob/660133db0d9024c197bf6d3893be4cae7df62a4f/src/internal/Subject.ts#L142

I tried to follow the coding style of the existing code and hesitated to use any semicolons. :-) Please let me know if there is anything I should change.